### PR TITLE
Add breakpoint property

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Via npm:
 npm i vue-screen
 ```
 
+Via yarn:
+```bash
+yarn add vue-screen
+```
+
+## Setup
 ```js
 import Vue from 'vue';
 import VueScreen from 'vue-screen';
@@ -118,6 +124,7 @@ After registering, the property `$screen` will be injected on the Vue prototype.
     <div>
         <p>Page width is {{ $screen.width }} px</p>
         <p>Page height is {{ $screen.height }} px</p>
+        <p>Current breakpoint is {{ $screen.breakpoint }} px</p>
     </div>
 </template>
 ```
@@ -180,6 +187,26 @@ Tells if the device is in portrait mode
 #### landscape 
 *Boolean*<br>
 Tells if the device is in landscape mode
+<br><br>
+#### breakpoint 
+*String*<br>
+Returns the currently active breakpoint. If you use custom breakpoint names, you must also provide the `breakpointsOrder` property (see below).
+<br><br>
+#### breakpointsOrder 
+*Array*<br>
+Contains the order of the custom breakpoints provided in the configuration. This is required for the `breakpoint` property to work with custom breakpoint names.
+<br>
+Example:
+```js
+Vue.use(VueScreen, {
+    phonePortrait: 0,
+    phoneLandscape: 520,
+    tabletPortrait: 768,
+    tabletLandscape: 1024,
+    desktop: 1200,
+    order: ['phonePortrait', 'phoneLandscape', 'tabletPortrait', 'tabletLandscape', 'desktop']
+});
+```
 <br><br>
 #### &lt;breakpoint key&gt;
 *Boolean*<br>

--- a/examples/grid/app.js
+++ b/examples/grid/app.js
@@ -7,30 +7,9 @@ const Test = {
   template: `
   <div>
     <div class="width">Width: <span>{{ $screen.width }}</span></div>
-    <div class="breakpoint">Breakpoint: <span>{{ breakpoint }}</span></div>
+    <div class="breakpoint">Breakpoint: <span>{{ $screen.breakpoint }}</span></div>
   </div>
   `,
-  computed: {
-    breakpoint() {
-      if (this.$screen.xl) {
-        return 'XL';
-      }
-
-      if (this.$screen.lg) {
-        return 'LG';
-      }
-
-      if (this.$screen.md) {
-        return 'MD';
-      }
-
-      if (this.$screen.sm) {
-        return 'SM';
-      }
-
-      return 'XS';
-    }
-  },
 };
 
 new Vue({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-screen",
-  "version": "1.1.2",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3433,7 +3433,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3454,12 +3455,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3474,17 +3477,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3601,7 +3607,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3613,6 +3620,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3627,6 +3635,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3634,12 +3643,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3658,6 +3669,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3738,7 +3750,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3750,6 +3763,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3835,7 +3849,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3871,6 +3886,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3890,6 +3906,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3933,12 +3950,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,17 @@
   "name": "vue-screen",
   "version": "1.1.5",
   "description": "Reactive window size and media query states for Vue components. Integrates with most UI frameworks.",
-  "keywords": ["vuejs", "window", "reactive window", "media query", "matchMedia", "innerWidth", "innerHeight"],
+  "keywords": [
+    "vuejs",
+    "window",
+    "reactive window",
+    "media query",
+    "matchMedia",
+    "innerWidth",
+    "innerHeight",
+    "grid",
+    "breakpoints"
+  ],
   "main": "dist/vue-screen.js",
   "scripts": {
     "test": "npm run lint && npm run test:unit && npm run test:e2e",

--- a/src/grids/bootstrap.js
+++ b/src/grids/bootstrap.js
@@ -1,4 +1,5 @@
 export default {
+  xs: 0,
   sm: 576,
   md: 768,
   lg: 992,

--- a/src/grids/bulma.js
+++ b/src/grids/bulma.js
@@ -1,4 +1,5 @@
 export default {
+  mobile: 0,
   tablet: 769,
   desktop: 1024,
   widescreen: 1216,

--- a/src/grids/foundation.js
+++ b/src/grids/foundation.js
@@ -1,4 +1,5 @@
 export default {
+  small: 0,
   medium: 640,
   large: 1024,
 };

--- a/src/grids/materialize.js
+++ b/src/grids/materialize.js
@@ -1,4 +1,5 @@
 export default {
+  s: 0,
   m: 601,
   l: 993,
   xl: 1201,

--- a/src/grids/semantic-ui.js
+++ b/src/grids/semantic-ui.js
@@ -1,4 +1,5 @@
 export default {
+  mobile: 0,
   tablet: 768,
   computer: 992,
   large: 1201,

--- a/src/grids/tailwind.js
+++ b/src/grids/tailwind.js
@@ -1,4 +1,5 @@
 export default {
+  xs: 0,
   sm: 576,
   md: 768,
   lg: 992,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -19,7 +19,19 @@ export const RESERVED_KEYS = [
   'touch',
   'portrait',
   'landscape',
+  'breakpoint',
 ];
+
+const CUSTOM_FRAMEWORK_NAME = '__CUSTOM__';
+
+export const DEFAULT_ORDERS = {
+  bootstrap: ['xs', 'sm', 'md', 'lg', 'xl'],
+  bulma: ['mobile', 'tablet', 'desktop', 'widescreen', 'fullhd'],
+  foundation: ['small', 'medium', 'large'],
+  materialize: ['s', 'm', 'l', 'xl'],
+  'semantic-ui': ['mobile', 'tablet', 'computer', 'large'],
+  tailwind: ['xs', 'sm', 'md', 'lg', 'xl'],
+};
 
 export class Plugin {
   /**
@@ -29,7 +41,7 @@ export class Plugin {
    */
   constructor(breakpoints = '') {
     this.callbacks = {};
-
+    this.framework = '';
     this.createScreen(
       Plugin.parseBreakpoints(breakpoints),
     );
@@ -45,21 +57,25 @@ export class Plugin {
   static parseBreakpoints(breakpoints) {
     if (typeof breakpoints === 'object') {
       if (breakpoints.extend) {
-        const framework = breakpoints.extend.toString();
+        this.framework = breakpoints.extend.toString();
         // eslint-disable-next-line no-param-reassign
         delete breakpoints.extend;
 
         return Object.assign(
           {},
           breakpoints,
-          Plugin.getBreakpoints(framework)
+          Plugin.getBreakpoints()
         );
       }
+
+      this.framework = CUSTOM_FRAMEWORK_NAME;
 
       return breakpoints;
     }
 
-    return Plugin.getBreakpoints(breakpoints.toString());
+    this.framework = breakpoints.toString();
+
+    return Plugin.getBreakpoints();
   }
 
   /**
@@ -68,17 +84,17 @@ export class Plugin {
    * @param {string} framework
    * @returns {object}
    */
-  static getBreakpoints(framework = '') {
-    if (!framework) {
+  static getBreakpoints() {
+    if (!this.framework) {
       // eslint-disable-next-line no-param-reassign
-      framework = DEFAULT_FRAMEWORK;
+      this.framework = DEFAULT_FRAMEWORK;
     }
 
-    if (!grids[framework]) {
-      throw new Error(`Cannot find grid breakpoints for framework "${framework}"`);
+    if (!grids[this.framework]) {
+      throw new Error(`Cannot find grid breakpoints for framework "${this.framework}"`);
     }
 
-    return grids[framework];
+    return grids[this.framework];
   }
 
   /**
@@ -111,6 +127,7 @@ export class Plugin {
       this.screen.height = window.innerHeight;
 
       this.runCallbacks();
+      this.findCurrentBreakpoint();
     }
   }
 
@@ -121,6 +138,22 @@ export class Plugin {
     Object.keys(this.callbacks).forEach((key) => {
       this.screen[key] = this.callbacks[key].call(null, this.screen);
     });
+  }
+
+  /**
+   * Calculate the current breakpoint name based on "order" property
+   */
+  findCurrentBreakpoint() {
+    this.screen.breakpoint = this.screen.breakpointsOrder.reduce(
+      (activeBreakpoint, currentBreakpoint) => {
+        if (this.screen[currentBreakpoint]) {
+          return currentBreakpoint;
+        }
+
+        return activeBreakpoint;
+      },
+      this.screen.breakpointsOrder[0]
+    );
   }
 
   /**
@@ -138,15 +171,20 @@ export class Plugin {
    * @param {object} breakpoints
    */
   createScreen(breakpoints) {
+    const breakpointKeys = Object.keys(breakpoints);
+
     this.screen = Vue.observable({
       width: DEFAULT_WIDTH,
       height: DEFAULT_HEIGHT,
       touch: true,
       portrait: true,
       landscape: false,
+      breakpointsOrder: DEFAULT_ORDERS[this.framework] || breakpointKeys,
     });
 
-    Object.keys(breakpoints).forEach((name) => {
+    this.screen.breakpoint = this.findCurrentBreakpoint();
+
+    breakpointKeys.forEach((name) => {
       if (RESERVED_KEYS.indexOf(name) >= 0) {
         throw new Error(`Invalid breakpoint name: "${name}". This key is reserved.`);
       }
@@ -173,8 +211,10 @@ export class Plugin {
         this.callbacks[name] = width;
       } else if (typeof width === 'number') {
         w = `${width}px`;
-      } else {
+      } else if (typeof width === 'string') {
         w = width;
+      } else {
+        this.screen[name] = width;
       }
 
       if (w) {

--- a/tests/e2e/grid.spec.js
+++ b/tests/e2e/grid.spec.js
@@ -5,11 +5,11 @@ describe('grid', () => {
 
   it('reacts to media query state changes', async () => {
     const page = await loadExample('grid');
-    await testBreakpoint(page, 400, 700, 'XS');
-    await testBreakpoint(page, 600, 700, 'SM');
-    await testBreakpoint(page, 800, 700, 'MD');
-    await testBreakpoint(page, 1000, 700, 'LG');
-    await testBreakpoint(page, 1300, 700, 'XL');
+    await testBreakpoint(page, 400, 700, 'xs');
+    await testBreakpoint(page, 600, 700, 'sm');
+    await testBreakpoint(page, 800, 700, 'md');
+    await testBreakpoint(page, 1000, 700, 'lg');
+    await testBreakpoint(page, 1300, 700, 'xl');
   });
 
 });

--- a/tests/units/helpers.js
+++ b/tests/units/helpers.js
@@ -23,6 +23,8 @@ export const breakpointsOnly = (screen) => {
   delete screen.touch;
   delete screen.portrait;
   delete screen.landscape;
+  delete screen.breakpoint;
+  delete screen.breakpointsOrder;
 
   return screen;
 }


### PR DESCRIPTION
This PR adds the `breakpoint` property to the `$screen` object.
Calculating the currently applied breakpoint by looking at breakpoint values is troublesome because they could be specified with mixed units, and to convert them all to pixels would require heavy `getComputedStyle` calls.
To keep the calculation lightweight, users are required to pass another property, `breakpointsOrder`, an array that returns the breakpoint names ordered from the smallest to the largest.
For supported frameworks, the `breakpointsOrder` is already provided by the library, so the property is only really required if users use different breakpoint names.